### PR TITLE
xbox: Fix LLVM 8.0 assembly compatibility

### DIFF
--- a/platform/xbox/_tls_array.s
+++ b/platform/xbox/_tls_array.s
@@ -1,4 +1,4 @@
 .data
 // _tls_array is a constant describing the offset of StackBase inside the NT TEB
 .globl __tls_array
-.equ __tls_array, 04h
+.equ __tls_array, 0x04


### PR DESCRIPTION
LLVM 8.0 seems to have brought changes to the accepted assembly syntax, it doesn't accept the 'h'-suffix anymore. This broke the build for macOS the day after the PDCLib merge.