### PR TITLE
Fix C++ compatibility

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -20,7 +20,9 @@ typedef _PDCLIB_ptrdiff_t ptrdiff_t;
 typedef _PDCLIB_size_t size_t;
 #endif
 
+#ifndef __cplusplus
 typedef _PDCLIB_wchar_t   wchar_t;
+#endif
 
 #ifndef _PDCLIB_NULL_DEFINED
 #define _PDCLIB_NULL_DEFINED _PDCLIB_NULL_DEFINED

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -64,7 +64,7 @@ int remove( const char * filename );
    If there already is a file with the new filename, behaviour is defined by
    the glue code (see functions/_PDCLIB/rename.c).
 */
-int rename( const char * old, const char * new );
+int rename( const char * old, const char * new_name );
 
 /* Open a temporary file with mode "wb+", i.e. binary-update. Remove the file
    automatically if it is closed or the program exits normally (by returning


### PR DESCRIPTION
stdio.h uses `new` as a parameter name for `rename()`, which conflicts with the C++ keyword, so I renamed the parameter.
stddef.h tries to redefine wchar_t, which seems to be a builtin type in C++, which makes redefining it forbidden.

**/edit:**
The issues in this PR have been reported (and partially fixed) upstream. As soon as the issues are fixed upstream, we can rebase and drop this PR.