### PR TITLE
Math improvements

### DIFF
--- a/platform/xbox/functions/fenv/env.c
+++ b/platform/xbox/functions/fenv/env.c
@@ -1,0 +1,28 @@
+#include <fenv.h>
+
+int fegetenv (fenv_t *envp)
+{
+    __asm__ ("fnstenv (%0);" : : "r"(envp));
+    return 0;
+}
+
+int feholdexcept (fenv_t *envp)
+{
+    fegetenv(envp);
+    feclearexcept(FE_ALL_EXCEPT);
+    return 0;
+}
+
+int fesetenv (const fenv_t *envp)
+{
+    __asm__ ("fldenv (%0);" : : "r"(envp));
+    return 0;
+}
+
+int feupdateenv (const fenv_t *envp)
+{
+    int exceptions = fetestexcept(FE_ALL_EXCEPT);
+    fesetenv(envp);
+    feraiseexcept(exceptions);
+    return 0;
+}

--- a/platform/xbox/functions/fenv/exceptions.c
+++ b/platform/xbox/functions/fenv/exceptions.c
@@ -1,0 +1,73 @@
+#include <fenv.h>
+#include <assert.h>
+#include <stdlib.h>
+
+int feclearexcept (int excepts)
+{
+    if ((excepts & FE_ALL_EXCEPT) != excepts) {
+        return -1;
+    }
+
+    if (excepts == FE_ALL_EXCEPT) {
+        __asm__ ("fnclex;");
+    } else {
+        fenv_t fenv;
+        fegetenv(&fenv);
+        fenv.status &= ~excepts;
+        fesetenv(&fenv);
+    }
+
+    return 0;
+}
+
+int fegetexceptflag (fexcept_t *flagp, int excepts)
+{
+    assert(flagp != NULL);
+
+    if ((excepts & FE_ALL_EXCEPT) != excepts) {
+        return -1;
+    }
+
+    unsigned short sw;
+    __asm__ ("fnstsw %0;" : : "m"(sw));
+    *flagp = sw & excepts;
+
+    return 0;
+}
+
+int feraiseexcept (int excepts)
+{
+    if ((excepts & FE_ALL_EXCEPT) != excepts) {
+        return -1;
+    }
+
+    fexcept_t flags = excepts;
+    fesetexceptflag(&flags, excepts);
+    __asm__ ("fwait;");
+
+    return 0;
+}
+
+int fesetexceptflag (const fexcept_t *flagp, int excepts)
+{
+    assert(flagp != NULL);
+
+    if ((excepts & FE_ALL_EXCEPT) != excepts) {
+        return -1;
+    }
+
+    fenv_t fenv;
+    fegetenv(&fenv);
+    fenv.status &= ~excepts;
+    fenv.status |= *flagp & excepts;
+    fesetenv(&fenv);
+
+    return 0;
+}
+
+int fetestexcept (int excepts)
+{
+    unsigned short sw;
+    __asm__ ("fnstsw %0;" : : "m"(sw));
+    return sw & excepts;
+}

--- a/platform/xbox/functions/fenv/rounding.c
+++ b/platform/xbox/functions/fenv/rounding.c
@@ -1,0 +1,23 @@
+#include <fenv.h>
+
+int fegetround (void)
+{
+    unsigned short fcw;
+    __asm__ ("fnstcw  %0;" : : "m"(fcw));
+    return fcw & 0xc00;
+}
+
+int fesetround (int round)
+{
+    if (round != FE_DOWNWARD && round != FE_TONEAREST && round != FE_TOWARDZERO && round != FE_UPWARD) {
+        return -1;
+    }
+
+    unsigned short fcw;
+    __asm__ ("fnstcw %0;"   // store control word
+             "andl %1, %0;" // mask out all rounding flags
+             "orl %2, %0;"  // set rounding mode flags
+             "fldcw %0;"    // load control word
+             : : "m"(fcw), "r"(0xc00), "r"(round));
+    return 0;
+}

--- a/platform/xbox/functions/math/ceil.c
+++ b/platform/xbox/functions/math/ceil.c
@@ -4,13 +4,15 @@ double ceil(double x)
 {
     unsigned short fcw;
 
-    __asm__ ("fnstcw %2;"
+    __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "orl %3, %2;"
-             "fldcw %2;"
-             "frndint;"
+             "andl %4, %2;"   // clear rounding bits in control word
+             "orl %3, %2;"    // set rounding mode to "round up"
+             "fldcw %2;"      // load modified control word
+             "frndint;"       // round the float
              "mov %%eax, %2;"
-             "fldcw %2;" : "=t"(x) : "0"(x), "m"(fcw), "r"(0x800) : "eax");
+             "fldcw %2;"      // restore original control word
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0x800), "r"(~0xc00) : "eax");
     return x;
 }
 
@@ -18,13 +20,15 @@ float ceilf(float x)
 {
     unsigned short fcw;
 
-    __asm__ ("fnstcw %2;"
+    __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "orl %3, %2;"
-             "fldcw %2;"
-             "frndint;"
+             "andl %4, %2;"   // clear rounding bits in control word
+             "orl %3, %2;"    // set rounding mode to "round up"
+             "fldcw %2;"      // load modified control word
+             "frndint;"       // round the float
              "mov %%eax, %2;"
-             "fldcw %2;" : "=t"(x) : "0"(x), "m"(fcw), "r"(0x800) : "eax");
+             "fldcw %2;"      // restore original control word
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0x800), "r"(~0xc00) : "eax");
     return x;
 }
 
@@ -32,12 +36,14 @@ long double ceill(long double x)
 {
     unsigned short fcw;
 
-    __asm__ ("fnstcw %2;"
+    __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "orl %3, %2;"
-             "fldcw %2;"
-             "frndint;"
+             "andl %4, %2;"   // clear rounding bits in control word
+             "orl %3, %2;"    // set rounding mode to "round up"
+             "fldcw %2;"      // load modified control word
+             "frndint;"       // round the float
              "mov %%eax, %2;"
-             "fldcw %2;" : "=t"(x) : "0"(x), "m"(fcw), "r"(0x800) : "eax");
+             "fldcw %2;"      // restore original control word
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0x800), "r"(~0xc00) : "eax");
     return x;
 }

--- a/platform/xbox/functions/math/floor.c
+++ b/platform/xbox/functions/math/floor.c
@@ -1,47 +1,49 @@
 #include <math.h>
-#include <assert.h>
 
-double round(double x)
+double floor(double x)
 {
     unsigned short fcw;
 
     __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "andl %3, %2;"   // clear rounding bits in control word ("round to nearest or even" mode)
+             "andl %4, %2;"   // clear rounding bits in control word
+             "orl %3, %2;"    // set rounding mode to "round down"
              "fldcw %2;"      // load modified control word
              "frndint;"       // round the float
              "mov %%eax, %2;"
              "fldcw %2;"      // restore original control word
-             : "=t"(x) : "0"(x), "m"(fcw), "r"(~0xc00) : "eax");
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0x400), "r"(~0xc00) : "eax");
     return x;
 }
 
-float roundf(float x)
+float floorf(float x)
 {
     unsigned short fcw;
 
     __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "andl %3, %2;"   // clear rounding bits in control word ("round to nearest or even" mode)
+             "andl %4, %2;"   // clear rounding bits in control word
+             "orl %3, %2;"    // set rounding mode to "round down"
              "fldcw %2;"      // load modified control word
              "frndint;"       // round the float
              "mov %%eax, %2;"
              "fldcw %2;"      // restore original control word
-             : "=t"(x) : "0"(x), "m"(fcw), "r"(~0xc00) : "eax");
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0x400), "r"(~0xc00) : "eax");
     return x;
 }
 
-long double roundl(long double x)
+long double floorl(long double x)
 {
     unsigned short fcw;
 
     __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "andl %3, %2;"   // clear rounding bits in control word ("round to nearest or even" mode)
+             "andl %4, %2;"   // clear rounding bits in control word
+             "orl %3, %2;"    // set rounding mode to "round down"
              "fldcw %2;"      // load modified control word
              "frndint;"       // round the float
              "mov %%eax, %2;"
              "fldcw %2;"      // restore original control word
-             : "=t"(x) : "0"(x), "m"(fcw), "r"(~0xc00) : "eax");
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0x400), "r"(~0xc00) : "eax");
     return x;
 }

--- a/platform/xbox/functions/math/fmax.c
+++ b/platform/xbox/functions/math/fmax.c
@@ -3,18 +3,51 @@
 
 double fmax(double x, double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    if (isnan(x)) {
+        return y;
+    }
+
+    if (isnan(y)) {
+        return x;
+    }
+
+    if (signbit(x) != signbit(y)) {
+        return signbit(x) ? y : x;
+    }
+
+    return x < y ? y : x;
 }
 
 float fmaxf(float x, float y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    if (isnan(x)) {
+        return y;
+    }
+
+    if (isnan(y)) {
+        return x;
+    }
+
+    if (signbit(x) != signbit(y)) {
+        return signbit(x) ? y : x;
+    }
+
+    return x < y ? y : x;
 }
 
 long double fmaxl(long double x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    if (isnan(x)) {
+        return y;
+    }
+
+    if (isnan(y)) {
+        return x;
+    }
+
+    if (signbit(x) != signbit(y)) {
+        return signbit(x) ? y : x;
+    }
+
+    return x < y ? y : x;
 }

--- a/platform/xbox/functions/math/fmin.c
+++ b/platform/xbox/functions/math/fmin.c
@@ -3,18 +3,51 @@
 
 double fmin(double x, double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    if (isnan(x)) {
+        return y;
+    }
+
+    if (isnan(y)) {
+        return x;
+    }
+
+    if (signbit(x) != signbit(y)) {
+        return signbit(x) ? x : y;
+    }
+
+    return x < y ? x : y;
 }
 
 float fminf(float x, float y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    if (isnan(x)) {
+        return y;
+    }
+
+    if (isnan(y)) {
+        return x;
+    }
+
+    if (signbit(x) != signbit(y)) {
+        return signbit(x) ? x : y;
+    }
+
+    return x < y ? x : y;
 }
 
 long double fminl(long double x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    if (isnan(x)) {
+        return y;
+    }
+
+    if (isnan(y)) {
+        return x;
+    }
+
+    if (signbit(x) != signbit(y)) {
+        return signbit(x) ? x : y;
+    }
+
+    return x < y ? x : y;
 }

--- a/platform/xbox/functions/math/fpclassify.c
+++ b/platform/xbox/functions/math/fpclassify.c
@@ -1,0 +1,28 @@
+#include <math.h>
+
+int __fpclassifyf (float x)
+{
+    unsigned short sw;
+    __asm__ ("fxam;"   // examine st(0)
+             "fstsw;"  // store status word in ax (sw variable) and do exception check
+             : "=a"(sw) : "t"(x));
+    return sw & (FP_NAN | FP_NORMAL | FP_ZERO);
+}
+
+int __fpclassify (double x)
+{
+    unsigned short sw;
+    __asm__ ("fxam;"   // examine st(0)
+             "fstsw;"  // store status word in ax (sw variable) and do exception check
+             : "=a"(sw) : "t"(x));
+    return sw & (FP_NAN | FP_NORMAL | FP_ZERO);
+}
+
+int __fpclassifyl (long double x)
+{
+    unsigned short sw;
+    __asm__ ("fxam;"   // examine st(0)
+             "fstsw;"  // store status word in ax (sw variable) and do exception check
+             : "=a"(sw) : "t"(x));
+    return sw & (FP_NAN | FP_NORMAL | FP_ZERO);
+}

--- a/platform/xbox/functions/math/nearbyint.c
+++ b/platform/xbox/functions/math/nearbyint.c
@@ -1,20 +1,37 @@
 #include <math.h>
-#include <assert.h>
+#include <fenv.h>
+
+#pragma STDC FENV_ACCESS ON
 
 double nearbyint(double x)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    int inexact_set;
+
+    inexact_set = fetestexcept(FE_INEXACT);
+    x = rint(x);
+    if (!inexact_set) feclearexcept(FE_INEXACT);
+
+    return x;
 }
 
 float nearbyintf(float x)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    int inexact_set;
+
+    inexact_set = fetestexcept(FE_INEXACT);
+    x = rintf(x);
+    if (!inexact_set) feclearexcept(FE_INEXACT);
+
+    return x;
 }
 
 long double nearbyintl(long double x)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    int inexact_set;
+
+    inexact_set = fetestexcept(FE_INEXACT);
+    x = rintl(x);
+    if (!inexact_set) feclearexcept(FE_INEXACT);
+
+    return x;
 }

--- a/platform/xbox/functions/math/rint.c
+++ b/platform/xbox/functions/math/rint.c
@@ -3,18 +3,21 @@
 
 double rint(double x)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    __asm__ ("frndint;"
+             : "=t"(x) : "0"(x));
+    return x;
 }
 
 float rintf(float x)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    __asm__ ("frndint;"
+             : "=t"(x) : "0"(x));
+    return x;
 }
 
 long double rintl(long double x)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    __asm__ ("frndint;"
+             : "=t"(x) : "0"(x));
+    return x;
 }

--- a/platform/xbox/functions/math/signbit.c
+++ b/platform/xbox/functions/math/signbit.c
@@ -1,0 +1,28 @@
+#include <math.h>
+
+int __signbitf (float x)
+{
+    unsigned short sw;
+    __asm__ ("fxam;"   // examine st(0)
+             "fstsw;"  // store status word in ax (sw variable) and do exception check
+             : "=a"(sw) : "t"(x));
+    return sw & 0x0200; // mask all except C1, which contains the sign bit
+}
+
+int __signbit (double x)
+{
+    unsigned short sw;
+    __asm__ ("fxam;"   // examine st(0)
+             "fstsw;"  // store status word in ax (sw variable) and do exception check
+             : "=a"(sw) : "t"(x));
+    return sw & 0x0200; // mask all except C1, which contains the sign bit
+}
+
+int __signbitl (long double x)
+{
+    unsigned short sw;
+    __asm__ ("fxam;"   // examine st(0)
+             "fstsw;"  // store status word in ax (sw variable) and do exception check
+             : "=a"(sw) : "t"(x));
+    return sw & 0x0200; // mask all except C1, which contains the sign bit
+}

--- a/platform/xbox/functions/math/trunc.c
+++ b/platform/xbox/functions/math/trunc.c
@@ -4,13 +4,14 @@ double trunc(double x)
 {
     unsigned short fcw;
 
-    __asm__ ("fnstcw %2;"
+    __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "orl %3, %2;"
-             "fldcw %2;"
-             "frndint;"
+             "orl %3, %2;"    // set all rounding bits in control word ("chop" mode)
+             "fldcw %2;"      // load modified control word
+             "frndint;"       // round the float
              "mov %%eax, %2;"
-             "fldcw %2;" : "=t"(x) : "0"(x), "m"(fcw), "r"(0xC00) : "eax");
+             "fldcw %2;"      // restore original control word
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0xC00) : "eax");
     return x;
 }
 
@@ -18,13 +19,14 @@ float truncf(float x)
 {
     unsigned short fcw;
 
-    __asm__ ("fnstcw %2;"
+    __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "orl %3, %2;"
-             "fldcw %2;"
-             "frndint;"
+             "orl %3, %2;"    // set all rounding bits in control word ("chop" mode)
+             "fldcw %2;"      // load modified control word
+             "frndint;"       // round the float
              "mov %%eax, %2;"
-             "fldcw %2;" : "=t"(x) : "0"(x), "m"(fcw), "r"(0xC00) : "eax");
+             "fldcw %2;"      // restore original control word
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0xC00) : "eax");
     return x;
 }
 
@@ -32,12 +34,13 @@ long double truncl(long double x)
 {
     unsigned short fcw;
 
-    __asm__ ("fnstcw %2;"
+    __asm__ ("fnstcw %2;"     // backup FPU control word
              "mov %2, %%eax;"
-             "orl %3, %2;"
-             "fldcw %2;"
-             "frndint;"
+             "orl %3, %2;"    // set all rounding bits in control word ("chop" mode)
+             "fldcw %2;"      // load modified control word
+             "frndint;"       // round the float
              "mov %%eax, %2;"
-             "fldcw %2;" : "=t"(x) : "0"(x), "m"(fcw), "r"(0xC00) : "eax");
+             "fldcw %2;"      // restore original control word
+             : "=t"(x) : "0"(x), "m"(fcw), "r"(0xC00) : "eax");
     return x;
 }

--- a/platform/xbox/include/fenv.h
+++ b/platform/xbox/include/fenv.h
@@ -1,0 +1,61 @@
+#ifndef _PDCLIB_FENV_H
+#define _PDCLIB_FENV_H _PDCLIB_FENV_H
+
+// 7.6.4
+// follows the format used by fnstenv/fldenv
+typedef struct _fenv_t
+{
+    unsigned short control;
+    unsigned short unused1;
+    unsigned short status;
+    unsigned short unused2;
+    unsigned short tag;
+    unsigned short unused3;
+    unsigned long other[4];
+} fenv_t;
+
+// 7.6.5
+typedef unsigned short fexcept_t;
+
+// 7.6.6
+// modelled after the x87 status word exception flags
+#define FE_INVALID   0x01
+#define FE_DIVBYZERO 0x04
+#define FE_OVERFLOW  0x08
+#define FE_UNDERFLOW 0x10
+#define FE_INEXACT   0x20
+// 7.6.7
+#define FE_ALL_EXCEPT (FE_DIVBYZERO | FE_INEXACT | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW)
+
+// 7.6.8
+// modelled after the x87 rounding flags
+#define FE_DOWNWARD   0x400
+#define FE_TONEAREST  0x000
+#define FE_TOWARDZERO 0xc00
+#define FE_UPWARD     0x800
+
+// 7.6.9
+static const fenv_t __fe_dfl_env = {0x037f, 0x0000,
+                                    0x0000, 0x0000,
+                                    0xffff, 0x0000,
+                                    0x00000000,
+                                    0x00000000,
+                                    0x00000000,
+                                    0x00000000};
+#define FE_DFL_ENV (&__fe_dfl_env)
+
+int feclearexcept (int excepts);
+int fegetexceptflag (fexcept_t *flagp, int excepts);
+int feraiseexcept (int excepts);
+int fesetexceptflag (const fexcept_t *flagp, int excepts);
+int fetestexcept (int excepts);
+
+int fegetround (void);
+int fesetround (int round);
+
+int fegetenv (fenv_t *envp);
+int feholdexcept (fenv_t *envp);
+int fesetenv (const fenv_t *envp);
+int feupdateenv (const fenv_t *envp);
+
+#endif


### PR DESCRIPTION
This contains all of my work to get math.h libc++-compatible, plus a few extras:

* minor fix for `ceil`, added comments
* implemented `floor`
* implemented `fmax`
* implemented `fmin`
* properly implemented `fpclassify`
* implemented `nearbyint`
* implemented `rint`
* implemented `round`
* comments added to `trunc`
* added `isfinite`
* reworked `isinf`, `isnan`, `isnormal` and `signbit`
* reworked `isgreater`, `isgreaterequal`, `isless`, `islessequal`, `islessgreater` and `isunordered`
* added `fenv.h` and implemented all of its functions