### PR TITLE
Add at_quick_exit() / quick_exit()

### DIFF
--- a/functions/stdlib/at_quick_exit.c
+++ b/functions/stdlib/at_quick_exit.c
@@ -1,0 +1,68 @@
+/* at_quick_exit( void (*)( void ) )
+
+   This file is part of the Public Domain C Library (PDCLib).
+   Permission is granted to use, modify, and / or redistribute at will.
+*/
+
+#include <stdlib.h>
+
+#ifndef REGTEST
+
+extern void (*_PDCLIB_quickexitstack[])( void );
+extern size_t _PDCLIB_quickexitptr;
+
+int at_quick_exit( void (*func)( void ) )
+{
+    if ( _PDCLIB_quickexitptr == _PDCLIB_ATEXIT_SLOTS )
+    {
+        return -1;
+    }
+    else
+    {
+        _PDCLIB_quickexitstack[ _PDCLIB_quickexitptr++ ] = func;
+        return 0;
+    }
+}
+
+#endif
+
+#ifdef TEST
+
+#include "_PDCLIB_test.h"
+
+#include <assert.h>
+
+static int flags[ 32 ];
+
+static void counthandler( void )
+{
+    static int count = 0;
+    flags[ count ] = count;
+    ++count;
+}
+
+static void checkhandler( void )
+{
+    int i;
+    for ( i = 0; i < 32; ++i )
+    {
+        assert( flags[ i ] == i );
+    }
+}
+
+int main( void )
+{
+#ifdef __ANDROID__
+    TESTCASE( NO_TESTDRIVER );
+#else
+    int i;
+    TESTCASE( at_quick_exit( &checkhandler ) == 0 );
+    for ( i = 0; i < 32; ++i )
+    {
+        TESTCASE( at_quick_exit( &counthandler ) == 0 );
+    }
+#endif
+    quick_exit(TEST_RESULTS);
+}
+
+#endif

--- a/functions/stdlib/quick_exit.c
+++ b/functions/stdlib/quick_exit.c
@@ -1,0 +1,40 @@
+/* quick_exit( int )
+
+   This file is part of the Public Domain C Library (PDCLib).
+   Permission is granted to use, modify, and / or redistribute at will.
+*/
+
+#include <stdlib.h>
+
+#ifndef REGTEST
+
+/* TODO - "...except that a function is called after any previously registered
+   functions that had already been called at the time it was registered."
+   (C standard regarding quick_exit)
+*/
+
+void (*_PDCLIB_quickexitstack[ _PDCLIB_ATEXIT_SLOTS ])( void ) = { _PDCLIB_closeall };
+size_t _PDCLIB_quickexitptr = 1;
+
+void quick_exit( int status )
+{
+    while ( _PDCLIB_quickexitptr != 0 )
+    {
+        _PDCLIB_quickexitstack[ --_PDCLIB_quickexitptr ]();
+    }
+    _Exit( status );
+}
+
+#endif
+
+#ifdef TEST
+
+#include "_PDCLIB_test.h"
+
+int main( void )
+{
+    /* Unwinding of regstack tested in at_quick_exit(). */
+    return TEST_RESULTS;
+}
+
+#endif

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -158,6 +158,21 @@ _PDCLIB_PUBLIC int atexit( void (*func)( void ) );
 */
 _PDCLIB_PUBLIC void exit( int status );
 
+/* Register a function that will be called on quick_exit().
+   At least 32 functions can be registered this way, and will be called in
+   reverse order of registration (last-in, first-out).
+   Returns zero if registration is successfull, nonzero if it failed.
+*/
+_PDCLIB_PUBLIC int at_quick_exit( void (*func)( void ) );
+
+/* Quick process termination. Functions registered by at_quick_exit() (see
+   above) are called, streams flushed, files closed and temporary files removed
+   before the program is terminated with the given status. (See comment for
+   EXIT_SUCCESS and EXIT_FAILURE above.)
+   quick_exit() does not return.
+*/
+_PDCLIB_PUBLIC void quick_exit( int status );
+
 /* Normal process termination. Functions registered by atexit() (see above) are
    NOT CALLED. This implementation DOES flush streams, close files and removes
    temporary files before the program is teminated with the given status. (See


### PR DESCRIPTION
This implements `at_quick_exit()` and `quick_exit()`. Both are C11 functions that are required by libc++.

No "xbox"-prefix for this commit since it's a generic implementation.