### PR TITLE
ptrdiff_t needs to be int, not long

### DIFF
--- a/platform/xbox/include/pdclib/_PDCLIB_config.h
+++ b/platform/xbox/include/pdclib/_PDCLIB_config.h
@@ -137,8 +137,8 @@ struct _PDCLIB_lldiv_t
 /* -------------------------------------------------------------------------- */
 
 /* The result type of substracting two pointers */
-#define _PDCLIB_ptrdiff long
-#define _PDCLIB_PTRDIFF LONG
+#define _PDCLIB_ptrdiff int
+#define _PDCLIB_PTRDIFF INT
 #define _PDCLIB_PTR_CONV l
 
 /* An integer type that can be accessed as atomic entity (think asynchronous


### PR DESCRIPTION
Fixes the definition of `_PDCLIB_ptrdiff` to be `int` instead of `long`, as it should be. Using the incorrect type breaks libc++ compilation because of mismatched types when instantiating a template in `streambuf`.