### PR TITLE
Provide wctrans_t and wctype_t

### DIFF
--- a/include/wctype.h
+++ b/include/wctype.h
@@ -15,8 +15,9 @@ extern "C" {
 
 typedef _PDCLIB_wint_t wint_t;
 
-// wctrans_t
-// wctype_t
+// Xbox-specific types to make this header work
+typedef int wctrans_t;
+typedef int wctype_t;
 
 #ifndef _PDCLIB_WEOF_DEFINED
 #define _PDCLIB_WEOF_DEFINED _PDCLIB_WEOF_DEFINED


### PR DESCRIPTION
`wctype.h` is missing these typedefs, which makes code that include this header fail to compile. As libc++ requires this header, this commit provides these typedefs. I checked Windows headers to be safe and `int` is in fact the correct type for these.