### PR TITLE
Switch to using winapi for file I/O

### DIFF
--- a/platform/xbox/functions/_PDCLIB/_PDCLIB_close.c
+++ b/platform/xbox/functions/_PDCLIB/_PDCLIB_close.c
@@ -12,11 +12,22 @@
 #ifndef REGTEST
 
 #include "pdclib/_PDCLIB_glue.h"
-#include <hal/fileio.h>
+#include <errno.h>
+#include <windows.h>
 
-int _PDCLIB_close( int fd )
+int _PDCLIB_w32errno( DWORD werror );
+
+int _PDCLIB_close( void *fd )
 {
-    return XCloseHandle( fd );
+    if ( CloseHandle( fd ) )
+    {
+        return 0;
+    }
+    else
+    {
+        *_PDCLIB_errno_func() = _PDCLIB_w32errno(GetLastError());
+        return -1;
+    }
 }
 
 #endif

--- a/platform/xbox/functions/_PDCLIB/_PDCLIB_fillbuffer.c
+++ b/platform/xbox/functions/_PDCLIB/_PDCLIB_fillbuffer.c
@@ -13,14 +13,17 @@
 
 #include "pdclib/_PDCLIB_glue.h"
 
-#include <hal/fileio.h>
+#include <errno.h>
+#include <windows.h>
+
+int _PDCLIB_w32errno( DWORD werror );
 
 int _PDCLIB_fillbuffer( struct _PDCLIB_file_t * stream )
 {
     /* No need to handle buffers > INT_MAX, as PDCLib doesn't allow them */
-    int status;
-    unsigned int amount_read;
-    status = XReadFile(stream->handle, stream->buffer, stream->bufsize, &amount_read);
+    BOOL status;
+    DWORD amount_read;
+    status = ReadFile(stream->handle, stream->buffer, stream->bufsize, &amount_read, NULL);
     if (status)
     {
         if (amount_read == 0)
@@ -42,8 +45,7 @@ int _PDCLIB_fillbuffer( struct _PDCLIB_file_t * stream )
     }
     else
     {
-        // FIXME: Translate returned errors to proper errno
-        //_PDCLIB_errno = _PDCLIB_ERROR;
+        *_PDCLIB_errno_func() = _PDCLIB_w32errno(GetLastError());
         stream->status |= _PDCLIB_ERRORFLAG;
         return EOF;
     }

--- a/platform/xbox/functions/_PDCLIB/_PDCLIB_rename.c
+++ b/platform/xbox/functions/_PDCLIB/_PDCLIB_rename.c
@@ -13,18 +13,20 @@
 
 #include "pdclib/_PDCLIB_glue.h"
 
-#include <hal/fileio.h>
+#include <errno.h>
+#include <windows.h>
+
+int _PDCLIB_w32errno( DWORD werror );
 
 int _PDCLIB_rename( const char * old, const char * new )
 {
-    if (XRenameFile(old, new) == STATUS_SUCCESS)
+    if ( MoveFileA(old, new) )
     {
         return 0;
     }
     else
     {
-        // FIXME: Translate returned errors to proper errno
-        //_PDCLIB_errno = _PDCLIB_ERROR;
+        *_PDCLIB_errno_func() = _PDCLIB_w32errno(GetLastError());
         return -1;
     }
 }

--- a/platform/xbox/functions/_PDCLIB/_PDCLIB_w32errno.c
+++ b/platform/xbox/functions/_PDCLIB/_PDCLIB_w32errno.c
@@ -1,0 +1,154 @@
+/* _PDCLIB_w32errno( DWORD )
+
+   This file is part of the Public Domain C Library (PDCLib).
+   Permission is granted to use, modify, and / or redistribute at will.
+*/
+
+#ifndef REGTEST
+#include <errno.h>
+#include <windows.h>
+
+int _PDCLIB_w32errno( DWORD werror )
+{
+    switch ( werror )
+    {
+        case ERROR_ACCESS_DENIED: return EACCES;
+        case ERROR_ACTIVE_CONNECTIONS: return EAGAIN;
+        case ERROR_ALREADY_EXISTS: return EEXIST;
+        case ERROR_BAD_LENGTH: return EINVAL;
+        case ERROR_BAD_DEVICE: return ENODEV;
+        case ERROR_BAD_EXE_FORMAT: return ENOEXEC;
+        case ERROR_BAD_NETPATH: return ENOENT;
+        case ERROR_BAD_NET_NAME: return ENOENT;
+        case ERROR_BAD_NET_RESP: return ENOSYS;
+        case ERROR_BAD_PATHNAME: return ENOENT;
+        case ERROR_BAD_PIPE: return EINVAL;
+        case ERROR_BAD_UNIT: return ENODEV;
+        case ERROR_BAD_USERNAME: return EINVAL;
+        case ERROR_BEGINNING_OF_MEDIA: return EIO;
+        case ERROR_BROKEN_PIPE: return EPIPE;
+        case ERROR_BUSY: return EBUSY;
+        case ERROR_BUS_RESET: return EIO;
+        case ERROR_CALL_NOT_IMPLEMENTED: return ENOSYS;
+        case ERROR_CANCELLED: return EINTR;
+        case ERROR_CANNOT_MAKE: return EPERM;
+        case ERROR_CHILD_NOT_COMPLETE: return EBUSY;
+        case ERROR_COMMITMENT_LIMIT: return EAGAIN;
+        case ERROR_CONNECTION_REFUSED: return ECONNREFUSED;
+        case ERROR_CRC: return EIO;
+        case ERROR_DEVICE_DOOR_OPEN: return EIO;
+        case ERROR_DEVICE_IN_USE: return EAGAIN;
+        case ERROR_DEVICE_REQUIRES_CLEANING: return EIO;
+        case ERROR_DEV_NOT_EXIST: return ENOENT;
+        case ERROR_DIRECTORY: return ENOTDIR;
+        case ERROR_DIR_NOT_EMPTY: return ENOTEMPTY;
+        case ERROR_DISK_CORRUPT: return EIO;
+        case ERROR_DISK_FULL: return ENOSPC;
+        case ERROR_DS_GENERIC_ERROR: return EIO;
+        case ERROR_DUP_NAME: return EEXIST;
+        case ERROR_EAS_DIDNT_FIT: return ENOSPC;
+        case ERROR_EAS_NOT_SUPPORTED: return ENOTSUP;
+        case ERROR_EA_LIST_INCONSISTENT: return EINVAL;
+        case ERROR_EA_TABLE_FULL: return ENOSPC;
+        case ERROR_END_OF_MEDIA: return ENOSPC;
+        case ERROR_EOM_OVERFLOW: return EIO;
+        case ERROR_EXE_MACHINE_TYPE_MISMATCH: return ENOEXEC;
+        case ERROR_EXE_MARKED_INVALID: return ENOEXEC;
+        case ERROR_FILEMARK_DETECTED: return EIO;
+        case ERROR_FILENAME_EXCED_RANGE: return ENAMETOOLONG;
+        case ERROR_FILE_CORRUPT: return EEXIST;
+        case ERROR_FILE_EXISTS: return EEXIST;
+        case ERROR_FILE_INVALID: return ENXIO;
+        case ERROR_FILE_NOT_FOUND: return ENOENT;
+        case ERROR_HANDLE_DISK_FULL: return ENOSPC;
+        case ERROR_HANDLE_EOF: return ENODATA;
+        case ERROR_INVALID_ADDRESS: return EINVAL;
+        case ERROR_INVALID_AT_INTERRUPT_TIME: return EINTR;
+        case ERROR_INVALID_BLOCK_LENGTH: return EIO;
+        case ERROR_INVALID_DATA: return EINVAL;
+        case ERROR_INVALID_DRIVE: return ENOENT;
+        case ERROR_INVALID_EA_NAME: return EINVAL;
+        case ERROR_INVALID_EXE_SIGNATURE: return ENOEXEC;
+        case ERROR_INVALID_FUNCTION: return ENOENT;
+        case ERROR_INVALID_HANDLE: return EBADF;
+        case ERROR_INVALID_NAME: return ENOENT;
+        case ERROR_INVALID_PARAMETER: return EINVAL;
+        case ERROR_INVALID_SIGNAL_NUMBER: return EINVAL;
+        case ERROR_IOPL_NOT_ENABLED: return ENOEXEC;
+        case ERROR_IO_DEVICE: return EIO;
+        case ERROR_IO_INCOMPLETE: return EAGAIN;
+        case ERROR_IO_PENDING: return EAGAIN;
+        case ERROR_LOCK_VIOLATION: return EBUSY;
+        case ERROR_MAX_THRDS_REACHED: return EAGAIN;
+        case ERROR_META_EXPANSION_TOO_LONG: return EINVAL;
+        case ERROR_MOD_NOT_FOUND: return ENOENT;
+        case ERROR_MORE_DATA: return EMSGSIZE;
+        case ERROR_NEGATIVE_SEEK: return EINVAL;
+        case ERROR_NETNAME_DELETED: return ENOENT;
+        case ERROR_NOACCESS: return EFAULT;
+        case ERROR_NONE_MAPPED: return EINVAL;
+        case ERROR_NONPAGED_SYSTEM_RESOURCES: return EAGAIN;
+        case ERROR_NOT_CONNECTED: return ENOLINK;
+        case ERROR_NOT_ENOUGH_MEMORY: return ENOMEM;
+        case ERROR_NOT_ENOUGH_QUOTA: return EIO;
+        case ERROR_NOT_OWNER: return EPERM;
+        case ERROR_NOT_READY: return EBUSY;
+        case ERROR_NOT_SAME_DEVICE: return EXDEV;
+        case ERROR_NOT_SUPPORTED: return ENOSYS;
+        case ERROR_NO_DATA: return EPIPE;
+        case ERROR_NO_DATA_DETECTED: return EIO;
+        case ERROR_NO_MEDIA_IN_DRIVE: return EPIPE;
+        case ERROR_NO_MORE_FILES: return ENODATA;
+        case ERROR_NO_MORE_ITEMS: return ENODATA;
+        case ERROR_NO_MORE_SEARCH_HANDLES: return ENFILE;
+        case ERROR_NO_PROC_SLOTS: return EAGAIN;
+        case ERROR_NO_SIGNAL_SENT: return EIO;
+        case ERROR_NO_SYSTEM_RESOURCES: return EFBIG;
+        case ERROR_NO_TOKEN: return EINVAL;
+        case ERROR_OPEN_FAILED: return EIO;
+        case ERROR_OPEN_FILES: return EAGAIN;
+        case ERROR_OUTOFMEMORY: return ENOMEM;
+        case ERROR_PAGED_SYSTEM_RESOURCES: return EAGAIN;
+        case ERROR_PAGEFILE_QUOTA: return EAGAIN;
+        case ERROR_PATH_NOT_FOUND: return ENOENT;
+        case ERROR_PIPE_BUSY: return EBUSY;
+        case ERROR_PIPE_CONNECTED: return EBUSY;
+        case ERROR_PIPE_LISTENING: return EPIPE;
+        case ERROR_PIPE_NOT_CONNECTED: return EEXIST;
+        case ERROR_POSSIBLE_DEADLOCK: return EDEADLK;
+        case ERROR_PRIVILEGE_NOT_HELD: return EPERM;
+        case ERROR_PROCESS_ABORTED: return EFAULT;
+        case ERROR_PROC_NOT_FOUND: return ESRCH;
+        case ERROR_REM_NOT_LIST: return EHOSTUNREACH;
+        case ERROR_SECTOR_NOT_FOUND: return EINVAL;
+        case ERROR_SEEK: return EINVAL;
+        case ERROR_SERVICE_REQUEST_TIMEOUT: return EBUSY;
+        case ERROR_SETMARK_DETECTED: return EIO;
+        case ERROR_SHARING_BUFFER_EXCEEDED: return ENOLCK;
+        case ERROR_SHARING_VIOLATION: return EBUSY;
+        case ERROR_SIGNAL_PENDING: return EBUSY;
+        case ERROR_SIGNAL_REFUSED: return EIO;
+        case ERROR_SXS_CANT_GEN_ACTCTX: return ENOENT;
+        case ERROR_THREAD_1_INACTIVE: return EINVAL;
+        case ERROR_TIMEOUT: return EBUSY;
+        case ERROR_TOO_MANY_LINKS: return EMLINK;
+        case ERROR_TOO_MANY_OPEN_FILES: return EMFILE;
+        case ERROR_UNEXP_NET_ERR: return EIO;
+        case ERROR_WAIT_NO_CHILDREN: return ECHILD;
+        case ERROR_WORKING_SET_QUOTA: return EAGAIN;
+        case ERROR_WRITE_PROTECT: return EROFS;
+        default: return ENOSYS;
+    }
+}
+
+#endif
+
+#ifdef TEST
+#include "_PDCLIB_test.h"
+
+int main( void )
+{
+    return TEST_RESULTS;
+}
+
+#endif

--- a/platform/xbox/functions/stdio/remove.c
+++ b/platform/xbox/functions/stdio/remove.c
@@ -11,9 +11,12 @@
 
 #ifndef REGTEST
 
+#include <errno.h>
 #include <string.h>
 
-#include <hal/fileio.h>
+#include <windows.h>
+
+int _PDCLIB_w32errno( DWORD werror );
 
 extern struct _PDCLIB_file_t * _PDCLIB_filelist;
 
@@ -31,14 +34,13 @@ int remove( const char * pathname )
         current = current->next;
     }
 
-    if ( XDeleteFile( pathname ) == STATUS_SUCCESS )
+    if ( DeleteFileA( pathname ) )
     {
         return 0;
     }
     else
     {
-        // FIXME: Translate returned errors to proper errno
-        //_PDCLIB_errno = _PDCLIB_ERROR;
+        *_PDCLIB_errno_func() = _PDCLIB_w32errno(GetLastError());
         return -1;
     }
 }

--- a/platform/xbox/include/pdclib/_PDCLIB_config.h
+++ b/platform/xbox/include/pdclib/_PDCLIB_config.h
@@ -279,7 +279,8 @@ typedef __builtin_va_list _PDCLIB_va_list;
 /* I/O ---------------------------------------------------------------------- */
 
 /* The type of the file descriptor returned by _PDCLIB_open(). */
-typedef int _PDCLIB_fd_t;
+/* It has to match the winapi HANDLE type                      */
+typedef void *_PDCLIB_fd_t;
 
 /* The value (of type _PDCLIB_fd_t) returned by _PDCLIB_open() if the operation
    failed.


### PR DESCRIPTION
Due to requiring properly mounted devices, this will be a breaking change for some users, so I recommend to merge this after #14.

This changes the file I/O functions in the xbox backend to use the winapi functions instead of the old X*-functions. I used PDCLib's shepherd-branch for flag reference, the `_PDCLIB_w32errno()` function for translating winapi errors to errno values also comes from there.

I gave this some testing, and it seemed to work fine, but I do recommend everyone to test their code with this to make sure this doesn't break in some specific cases.