### PR TITLE
Fix C++ version of isfinite()

### DIFF
--- a/platform/xbox/include/math.h
+++ b/platform/xbox/include/math.h
@@ -90,7 +90,7 @@ int __signbitl (long double x);
         inline int fpclassify (double x) { return __fpclassify(x); };
         inline int fpclassify (long double x) { return __fpclassifyl(x); };
         template <typename T>
-        inline int isfinite (T x) { return #define isfinite(x) ((fpclassify(x) & FP_NAN) == 0); };
+        inline int isfinite (T x) { return ((fpclassify(x) & FP_NAN) == 0); };
         template <typename T>
         inline int isinf (T x) { return (fpclassify(x) == FP_INFINITE); };
         template <typename T>


### PR DESCRIPTION
I had a copy&paste mistake in the C++-specific version of `isfinite()`. As it's a template, it only broke as soon as it was actually called from C++.