### PR TITLE
Use local labels in inline asm of assert() implementation

### DIFF
--- a/platform/xbox/functions/assert/assert.c
+++ b/platform/xbox/functions/assert/assert.c
@@ -12,8 +12,8 @@ void _xbox_assert(char const * const expression, char const * const file_name, c
     #else
         debugPrint("\nAssertion failed: '%s' in function '%s', file '%s', line %u\n", expression, function_name, file_name, line);
         __asm__ ("cli\n"
-                 ".l:\n"
+                 "1:\n"
                  "hlt\n"
-                 "jmp .l\n");
+                 "jmp 1b\n");
     #endif
 }


### PR DESCRIPTION
The name of the label currently used in our `assert()` implementation can cause issues when using LTO. The linker may try to inline the function, which causes an error because there are then multiple labels with the same name. This did happen to me yesterday when I was experimenting with LTO.

This fixes that issue by replacing the label with a [local label](https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_5.html#SEC48) (link leads to gas docs, but LLVM follows the same behavior).