### PR TITLE
xbox: Fix lld dropping the _tls_index symbol when using LTO

### DIFF
--- a/platform/xbox/tls.c
+++ b/platform/xbox/tls.c
@@ -1,6 +1,7 @@
 #include <xboxkrnl/xboxkrnl.h>
 #include <pdclib/_PDCLIB_xbox_tls.h>
 
+#pragma comment(linker, "/include:__tls_index")
 ULONG _tls_index = 0;
 
 __attribute__((section(".tls"))) char _tls_start = 0;


### PR DESCRIPTION
For some reason `_tls_index` seems to get dropped somewhere when using LTO, even though it's implicitly referenced. I'm not sure what exactly causes this, and whether this is expected with this special symbol, or a bug in clang, or lld...

Adding a linker pragma fixes this, though. It should only be added when the obj file is pulled in, so it should be fine to have it there.