### PR TITLE
xbox: Cleanup assert.c

### DIFF
--- a/platform/xbox/functions/assert/assert.c
+++ b/platform/xbox/functions/assert/assert.c
@@ -1,19 +1,21 @@
 #include <assert.h>
-#include <debug.h>
 #include <stdlib.h>
-#include "xboxkrnl/xboxkrnl.h"
+
+#include <hal/debug.h>
+
+#include <xboxkrnl/xboxkrnl.h>
 
 void _xbox_assert(char const * const expression, char const * const file_name, char const * const function_name, unsigned long line)
 {
-    #ifdef DEBUG_CONSOLE
-        char buffer[512];
-        snprintf(buffer, 512, "In function '%s': ", function_name);
-        RtlAssert((PVOID)expression, (PVOID)file_name, line, buffer);
-    #else
-        debugPrint("\nAssertion failed: '%s' in function '%s', file '%s', line %u\n", expression, function_name, file_name, line);
-        __asm__ ("cli\n"
-                 "1:\n"
-                 "hlt\n"
-                 "jmp 1b\n");
-    #endif
+#ifdef DEBUG_CONSOLE
+    char buffer[512];
+    snprintf(buffer, 512, "In function '%s': ", function_name);
+    RtlAssert((PVOID)expression, (PVOID)file_name, line, buffer);
+#else
+    debugPrint("\nAssertion failed: '%s' in function '%s', file '%s', line %u\n", expression, function_name, file_name, line);
+    __asm__ ("cli\n"
+             "1:\n"
+             "hlt\n"
+             "jmp 1b\n");
+#endif
 }


### PR DESCRIPTION
- I want to remove `hal/` from the include directories soon, so you'll need to use the full path.
This was the primary motivation for this PR.
- Also xboxkrnl is considered to be a system path in nxdk, so `<>` should be used for the include.
- I also grouped the includes into libc, hal lib and xboxkrnl lib.
- I then also removed the weird indentation.