### PR TITLE
xbox: Fix incorrect behavior of log, exp and pow functions

### DIFF
--- a/platform/xbox/functions/math/copysign.c
+++ b/platform/xbox/functions/math/copysign.c
@@ -1,20 +1,30 @@
 #include <math.h>
 #include <assert.h>
+#include <stdint.h>
 
 double copysign(double x, double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    uint32_t *x_raw = (uint32_t *)&x;
+    uint32_t *y_raw = (uint32_t *)&y;
+
+    x_raw[1] = (x_raw[1] & 0x7FFFFFFF) | (y_raw[1] & 0x80000000);
+    return x;
 }
 
 float copysignf(float x, float y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    uint32_t *x_raw = (uint32_t *)&x;
+    uint32_t *y_raw = (uint32_t *)&y;
+
+    *x_raw = (*x_raw & 0x7FFFFFFF) | (*y_raw & 0x80000000);
+    return x;
 }
 
 long double copysignl(long double x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    uint32_t *x_raw = (uint32_t *)&x;
+    uint32_t *y_raw = (uint32_t *)&y;
+
+    x_raw[1] = (x_raw[1] & 0x7FFFFFFF) | (y_raw[1] & 0x80000000);
+    return x;
 }

--- a/platform/xbox/functions/math/exp.c
+++ b/platform/xbox/functions/math/exp.c
@@ -1,7 +1,18 @@
 #include <math.h>
+#include <stdint.h>
 
 double exp(double x)
 {
+    uint32_t *raw_bits = (uint32_t *)&x;
+    if ((raw_bits[1] & 0x7FFFFFFF) >= 0x7FF00000) {
+        // value is -INFINITY, INFINITY, -NAN or NAN
+        if (raw_bits[1] == 0xFFF00000 && raw_bits[0] == 0) {
+            // value is -INFINITY
+            return 0;
+        }
+        return x;
+    }
+
     __asm__ ("fldl2e;"
              "fmulp;"
              "fld %%st(0);"
@@ -19,6 +30,16 @@ double exp(double x)
 
 float expf(float x)
 {
+    uint32_t *raw_bits = (uint32_t *)&x;
+    if ((*raw_bits & 0x7FFFFFFF) >= 0x7F800000) {
+        // value is -INFINITY, INFINITY, -NAN or NAN
+        if (*raw_bits == 0xFF800000) {
+            // value is -INFINITY
+            return 0;
+        }
+        return x;
+    }
+
     __asm__ ("fldl2e;"
              "fmulp;"
              "fld %%st(0);"
@@ -36,6 +57,16 @@ float expf(float x)
 
 long double expl(long double x)
 {
+    uint32_t *raw_bits = (uint32_t *)&x;
+    if ((raw_bits[1] & 0x7FFFFFFF) >= 0x7FF00000) {
+        // value is -INFINITY, INFINITY, -NAN or NAN
+        if (raw_bits[1] == 0xFFF00000 && raw_bits[0] == 0) {
+            // value is -INFINITY
+            return 0;
+        }
+        return x;
+    }
+
     __asm__ ("fldl2e;"
              "fmulp;"
              "fld %%st(0);"

--- a/platform/xbox/functions/math/log.c
+++ b/platform/xbox/functions/math/log.c
@@ -2,30 +2,24 @@
 
 double log(double x)
 {
-    if (x <= 0.0) return NAN;
-
-    __asm__ ("fyl2x;"
-             "fldl2e;"
-             "fdivrp" : "=t"(x) : "0"(x), "u"(1.0));
+    __asm__ ("fldln2;"
+             "fxch;"
+             "fyl2x;" : "=t"(x) : "0"(x));
     return x;
 }
 
 float logf(float x)
 {
-    if (x <= 0.0f) return NAN;
-
-    __asm__ ("fyl2x;"
-             "fldl2e;"
-             "fdivrp" : "=t"(x) : "0"(x), "u"(1.0f));
+    __asm__ ("fldln2;"
+             "fxch;"
+             "fyl2x;" : "=t"(x) : "0"(x));
     return x;
 }
 
 long double logl(long double x)
 {
-    if (x <= 0.0) return NAN;
-
-    __asm__ ("fyl2x;"
-             "fldl2e;"
-             "fdivrp" : "=t"(x) : "0"(x), "u"(1.0));
+    __asm__ ("fldln2;"
+             "fxch;"
+             "fyl2x;" : "=t"(x) : "0"(x));
     return x;
 }

--- a/platform/xbox/functions/math/pow.c
+++ b/platform/xbox/functions/math/pow.c
@@ -2,15 +2,48 @@
 
 double pow(double x, double y)
 {
-    return exp(y*log(x));
+    if (x < 0.0 && y != trunc(y)) {
+        // Negative base and non-integer exponent
+        return -NAN;
+    }
+
+    float r = exp(y * log(fabs(x)));
+
+    if (x < 0.0 && remainder(y, 2.0) != 0) {
+        r = -r;
+    }
+
+    return r;
 }
 
 float powf(float x, float y)
 {
-    return expf(y*logf(x));
+    if (x < 0.0f && y != truncf(y)) {
+        // Negative base and non-integer exponent
+        return -NAN;
+    }
+
+    float r = expf(y * logf(fabsf(x)));
+
+    if (x < 0.0f && remainderf(y, 2.0f) != 0) {
+        r = -r;
+    }
+
+    return r;
 }
 
 long double powl(long double x, long double y)
 {
-    return expl(y*logl(x));
+    if (x < 0.0 && y != truncl(y)) {
+        // Negative base and non-integer exponent
+        return -NAN;
+    }
+
+    float r = expl(y * logl(fabsl(x)));
+
+    if (x < 0.0 && remainderl(y, 2.0) != 0) {
+        r = -r;
+    }
+
+    return r;
 }

--- a/platform/xbox/functions/math/remainder.c
+++ b/platform/xbox/functions/math/remainder.c
@@ -3,18 +3,18 @@
 
 double remainder(double x, double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    __asm__ ("fprem1;" : "=t"(x) : "0"(x), "u"(y));
+    return x;
 }
 
 float remainderf(float x, float y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    __asm__ ("fprem1;" : "=t"(x) : "0"(x), "u"(y));
+    return x;
 }
 
 long double remainderl(long double x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    __asm__ ("fprem1;" : "=t"(x) : "0"(x), "u"(y));
+    return x;
 }


### PR DESCRIPTION
This fixes the issues in SDL's sampling rate conversion caused by our math functions. `log` and `exp` incorrectly handled special values (`INFINITY`, `-INFINITY`, `NAN` and `-NAN`). `log` was fixed by slightly tweaking the algorithm, while `exp` does check for special values before calculating (this approach seems to be common, I've seen it in Sortix's libm, too).

The problem in `pow`, and this is the main reason why SDL would hang, was that it would return `NAN` for negative bases (the logarithm of a negative number is a complex number). This was fixed by simply using the absolute value of the base. I also added glibc's behavior of returning `-NAN` when the function is called with a negative base and a non-integer exponent.

The behavior of all functions modified here was checked against glibc using positive, negative and special values. I have some test code [here](https://gist.github.com/thrimbor/c1f4b18ecd8be001f414f5a25d72716b) to verify that the SDL issue is solved (remember to enable `HAVE_POW` in `SDL_config_xbox.h` - the sample should hang without the changes and work with them).

Closes #25.