### PR TITLE
xbox: Implement nexttoward()

### DIFF
--- a/platform/xbox/functions/math/nexttoward.c
+++ b/platform/xbox/functions/math/nexttoward.c
@@ -1,20 +1,80 @@
+// Adapted from public domain code by Danny Smith <dannysmith@users.sourceforge.net>
+
 #include <math.h>
 #include <assert.h>
 
+
 double nexttoward(double x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    union
+    {
+        double d;
+        unsigned long long ll;
+    } u;
+
+    long double xx = x;
+
+    if (isnan (y) || isnan (x)) {
+        return x + y;
+    }
+
+    if (xx == y) {
+        /* nexttoward (0.0, -O.0) should return -0.0.  */
+        return y;
+    }
+    u.d = x;
+    if (x == 0.0) {
+        u.ll = 1;
+        return y > 0.0l ? u.d : -u.d;
+    }
+
+    /* Non-extended encodings are lexicographically ordered,
+       with implicit "normal" bit.  */
+    if (((x > 0.0) ^ (y > xx)) == 0) {
+        u.ll++;
+    } else {
+        u.ll--;
+    }
+    return u.d;
 }
 
 float nexttowardf(float x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    union
+    {
+        float f;
+        unsigned int i;
+    } u;
+
+    long double xx = x;
+
+    if (isnan (y) || isnan (x)) {
+        return x + y;
+    }
+
+    if (xx == y) {
+        /* nexttowardf (0.0, -O.0) should return -0.0.  */
+        return y;
+    }
+    u.f = x;
+    if (x == 0.0f) {
+        u.i = 1;
+        return y > 0.0l ? u.f : -u.f;
+    }
+
+    /* Non-extended encodings are lexicographically ordered,
+       with implicit "normal" bit.  */
+    if (((x > 0.0f) ^ (y > xx)) == 0) {
+        u.i++;
+    } else {
+        u.i--;
+    }
+    return u.f;
 }
 
 long double nexttowardl(long double x, long double y)
 {
-    assert(0); // Not implemented
-    return 0.0;
+    static_assert(sizeof(double) == sizeof(long double), "long double and double must be the same size.");
+
+    return nexttoward(x, y);
 }


### PR DESCRIPTION
I saw that @Ryzee119's Peanut-GB port works around our lack of `nexttowardf`, so I decided to quickly add an implementation. The code is taken from a [public domain implementation by Danny Smith](https://cygwin.com/git/?p=newlib-cygwin.git;a=blob;f=winsup/cygwin/math/nexttoward.c;h=8b6a83cbdd43689376c3a4aa06790821e14a5ad6;hb=HEAD) and slightly adapted (mostly indentation and curly braces changes).
Even though the code comes from Cygwin and I expect it to be tested, I ran a few quick tests against glibc, using positive and negative numbers as well as combinations with `NAN` and `INFINITY`, and the results matched.