### PR TITLE
xbox: time: Remove extraneous multiplication

### DIFF
--- a/platform/xbox/functions/time/time.c
+++ b/platform/xbox/functions/time/time.c
@@ -9,7 +9,7 @@
 #ifndef REGTEST
 
 #include <xboxkrnl/xboxkrnl.h>
-#define NT_EPOCH_TIME_OFFSET ((LONGLONG)(369 * 365 + 89) * 24 * 3600 * 10000000)
+#define NT_EPOCH_TIME_OFFSET ((LONGLONG)(369 * 365 + 89) * 24 * 3600)
 
 time_t time( time_t * timer )
 {
@@ -17,9 +17,8 @@ time_t time( time_t * timer )
     LARGE_INTEGER cur_time;
 
     KeQuerySystemTime(&cur_time);
-    cur_time.QuadPart -= NT_EPOCH_TIME_OFFSET;
 
-    result = (time_t)(cur_time.QuadPart / 10000000);
+    result = (time_t)((cur_time.QuadPart / 10000000) - NT_EPOCH_TIME_OFFSET);
 
     if (timer != NULL)
     {


### PR DESCRIPTION
Save microscopic amounts of time by removing one multiplication operation.