### PR TITLE
xbox: Use Win32 functions as a backend for C11 threads / TSS

### DIFF
--- a/platform/xbox/crt0.c
+++ b/platform/xbox/crt0.c
@@ -29,12 +29,6 @@ void _PDCLIB_xbox_libc_deinit ()
 
 static int main_wrapper ()
 {
-    _PDCLIB_xbox_tss_init();
-
-    _PDCLIB_xbox_libc_init();
-
-    _PDCLIB_xbox_run_crt_initializers();
-
     int retval;
     char *_argv = 0;
     retval = main(0, &_argv);
@@ -55,6 +49,9 @@ void XboxCRTEntry ()
     tlssize = (tlssize + 15) & ~15;
     tlssize += 4;
     *((DWORD *)_tls_used.AddressOfIndex) = (int)tlssize / -4;
+
+    _PDCLIB_xbox_libc_init();
+    _PDCLIB_xbox_run_crt_initializers();
 
     thrd_t main_thread;
     thrd_create(&main_thread, main_wrapper, NULL);

--- a/platform/xbox/functions/threads/_PDCLIB_xbox_tss_init.c
+++ b/platform/xbox/functions/threads/_PDCLIB_xbox_tss_init.c
@@ -1,7 +1,0 @@
-#include <threads.h>
-#include <pdclib/_PDCLIB_xbox_tss.h>
-
-void _PDCLIB_xbox_tss_init()
-{
-    mtx_init(&tss_lock, mtx_plain);
-}

--- a/platform/xbox/functions/threads/thrd_create.c
+++ b/platform/xbox/functions/threads/thrd_create.c
@@ -1,10 +1,29 @@
 #include <threads.h>
 #include <assert.h>
-#include <string.h>
-#include <pdclib/_PDCLIB_xbox_tls.h>
-#include <xboxkrnl/xboxkrnl.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <pdclib/_PDCLIB_xbox_tss.h>
 
-static VOID NTAPI _PDCLIB_xbox_thread_startup (PKSTART_ROUTINE StartRoutine, PVOID StartContext);
+struct thread_info_t {
+    thrd_start_t func;
+    void *arg;
+};
+
+static __stdcall DWORD thread_wrapper (LPVOID lpThreadParameter)
+{
+    struct thread_info_t *thread_info = (struct thread_info_t *)lpThreadParameter;
+
+    thrd_start_t func = thread_info->func;
+    void *arg = thread_info->arg;
+
+    free(lpThreadParameter);
+
+    int res = func(arg);
+
+    _PDCLIB_xbox_tss_cleanup();
+
+    return (DWORD)res;
+}
 
 int thrd_create (thrd_t *thr, thrd_start_t func, void *arg)
 {
@@ -12,49 +31,19 @@ int thrd_create (thrd_t *thr, thrd_start_t func, void *arg)
         return thrd_error;
     }
 
-    NTSTATUS ntstatus;
-    ULONG stacksize;
-    ULONG tlssize;
-    // FIXME: We're directly reading the XBE StackCommit field here.
-    //        A cleaner way with proper structs would be nice.
-    stacksize = *((ULONG *)0x00010130);
-    // Sum up the required amount of memory, round it up to a multiple of
-    // 16 bytes and add 4 bytes for the self-reference
-    tlssize = (_tls_used.EndAddressOfRawData - _tls_used.StartAddressOfRawData) + _tls_used.SizeOfZeroFill;
-    tlssize = (tlssize + 15) & ~15;
-    tlssize += 4;
-    ntstatus = PsCreateSystemThreadEx(&thr->handle, 0, stacksize, tlssize, &thr->id, (PKSTART_ROUTINE)func, arg, FALSE, FALSE, _PDCLIB_xbox_thread_startup);
-
-    if (NT_SUCCESS(ntstatus))
-    {
-        return thrd_success;
+    struct thread_info_t *thread_info = malloc(sizeof(struct thread_info_t));
+    if (!thread_info) {
+        return thrd_nomem;
     }
 
-    return thrd_error;
-}
+    thread_info->func = func;
+    thread_info->arg = arg;
 
-VOID NTAPI _PDCLIB_xbox_thread_startup (PKSTART_ROUTINE StartRoutine, PVOID StartContext)
-{
-    // Make sure the TLS pointer is valid
-    assert(KeGetCurrentThread()->TlsData);
+    *thr = CreateThread(NULL, 0, thread_wrapper, (void *)thread_info, 0, NULL);
+    if (!*thr) {
+        free(thread_info);
+        return thrd_error;
+    }
 
-    // Retrieve TLS area address and point first entry to itself
-    DWORD *TlsData;
-    TlsData = ((DWORD *)KeGetCurrentThread()->TlsData) + 1;
-    TlsData[-1] = (DWORD)TlsData;
-
-    // 16 byte alignment required
-    assert(((DWORD)TlsData & 15) == 0);
-
-    // Copy initial values of TLS area
-    DWORD TlsDataSize;
-    TlsDataSize = _tls_used.EndAddressOfRawData - _tls_used.StartAddressOfRawData;
-    memcpy(TlsData, (void *)_tls_used.StartAddressOfRawData, TlsDataSize);
-
-    // Zero-initialize the rest
-    RtlZeroMemory((char *)TlsData + TlsDataSize, _tls_used.SizeOfZeroFill);
-
-    int res;
-    res = ((thrd_start_t)StartRoutine)(StartContext);
-    thrd_exit(res);
+    return thrd_success;
 }

--- a/platform/xbox/functions/threads/thrd_current.c
+++ b/platform/xbox/functions/threads/thrd_current.c
@@ -1,10 +1,7 @@
 #include <threads.h>
-#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
 
 thrd_t thrd_current (void)
 {
-    thrd_t thrd;
-    thrd.handle = NULL;
-    thrd.id = ((PETHREAD)KeGetCurrentThread())->UniqueThread;
-    return thrd;
+    return GetCurrentThread();
 }

--- a/platform/xbox/functions/threads/thrd_detach.c
+++ b/platform/xbox/functions/threads/thrd_detach.c
@@ -1,19 +1,11 @@
 #include <threads.h>
-#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
 
 int thrd_detach (thrd_t thr)
 {
-    if (thr.handle == NULL)
-    {
-        return thrd_error;
-    }
-
-    if (NT_SUCCESS(NtClose(thr.handle)))
-    {
+    if (CloseHandle(thr)) {
         return thrd_success;
     }
-    else
-    {
-        return thrd_error;
-    }
+
+    return thrd_error;
 }

--- a/platform/xbox/functions/threads/thrd_equal.c
+++ b/platform/xbox/functions/threads/thrd_equal.c
@@ -1,9 +1,8 @@
 #include <threads.h>
 #include <stdbool.h>
-#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
 
 int thrd_equal (thrd_t thr0, thrd_t thr1)
 {
-    // Compare thread-IDs
-    return (thr0.id == thr1.id);
+    return (GetThreadId(thr0) == GetThreadId(thr1));
 }

--- a/platform/xbox/functions/threads/thrd_exit.c
+++ b/platform/xbox/functions/threads/thrd_exit.c
@@ -5,5 +5,6 @@
 _Noreturn void thrd_exit (int res)
 {
     _PDCLIB_xbox_tss_cleanup();
-    PsTerminateSystemThread(res);
+    ExitThread((DWORD)res);
+    while (1); // Suppresses noreturn warning
 }

--- a/platform/xbox/functions/threads/thrd_join.c
+++ b/platform/xbox/functions/threads/thrd_join.c
@@ -1,33 +1,21 @@
 #include <threads.h>
-#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
 
 int thrd_join (thrd_t thr, int *res)
 {
-    if (thr.handle == NULL)
-    {
+    if (WaitForSingleObject(thr, INFINITE) == WAIT_FAILED) {
         return thrd_error;
     }
 
-    NTSTATUS status = NtWaitForSingleObject(thr.handle, FALSE, NULL);
-    if (status != STATUS_WAIT_0)
-    {
-        return thrd_error;
-    }
-
-    if (res)
-    {
-        PETHREAD threadObject;
-        if (!NT_SUCCESS(ObReferenceObjectByHandle(thr.handle, NULL, (PVOID *)&threadObject)))
-        {
+    if (res) {
+        DWORD thread_result;
+        if (GetExitCodeThread(thr, &thread_result) != 0) {
+            *res = (int)thread_result;
+        } else {
             return thrd_error;
         }
-
-        *res = threadObject->ExitStatus;
-
-        ObfDereferenceObject(threadObject);
     }
 
-    NtClose(thr.handle);
-
+    CloseHandle(thr);
     return thrd_success;
 }

--- a/platform/xbox/functions/threads/thrd_yield.c
+++ b/platform/xbox/functions/threads/thrd_yield.c
@@ -1,7 +1,7 @@
 #include <threads.h>
-#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
 
 void thrd_yield (void)
 {
-    NtYieldExecution();
+    SwitchToThread();
 }

--- a/platform/xbox/functions/threads/tss_create.c
+++ b/platform/xbox/functions/threads/tss_create.c
@@ -1,37 +1,17 @@
 #include <threads.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <windows.h>
+#include <xboxkrnl/xboxkrnl.h>
 #include <pdclib/_PDCLIB_xbox_tss.h>
-
-mtx_t tss_lock;
-// Note: This uses range-based initialization, which is a GNU C extension
-thread_local void *tss_slots[TSS_SLOTS_NUM] = {[0 ... TSS_SLOTS_NUM-1] = NULL};
-tss_dtor_t tss_dtors[TSS_SLOTS_NUM] = {[0 ... TSS_SLOTS_NUM-1] = NULL};
-uint32_t tss_bitmap[TSS_SLOTS_NUM / 32] = {[0 ... (TSS_SLOTS_NUM/32)-1] = 0xFFFFFFFF};
 
 int tss_create (tss_t *key, tss_dtor_t dtor)
 {
-    int retval = thrd_error;
-
-    mtx_lock(&tss_lock);
-
-    for (size_t i=0; i < (TSS_SLOTS_NUM/32); i++)
-    {
-        if (tss_bitmap[i] == 0) continue;
-
-        unsigned int index = __builtin_ctz(tss_bitmap[i]);
-        // Unset the bit
-        tss_bitmap[i] &= ~(1 << index);
-        *key = i*32 + index;
-        retval = thrd_success;
-        break;
+    *key = TlsAlloc();
+    if (*key == TLS_OUT_OF_INDEXES) {
+        return thrd_error;
     }
 
-    mtx_unlock(&tss_lock);
-
-    if (retval == thrd_success)
-    {
-        tss_dtors[*key] = dtor;
-    }
-
-    return retval;
+    tss_dtors[*key] = dtor;
+    return thrd_success;
 }

--- a/platform/xbox/functions/threads/tss_delete.c
+++ b/platform/xbox/functions/threads/tss_delete.c
@@ -1,16 +1,10 @@
 #include <threads.h>
 #include <assert.h>
+#include <windows.h>
 #include <pdclib/_PDCLIB_xbox_tss.h>
 
 void tss_delete (tss_t key)
 {
-    assert(key < TSS_SLOTS_NUM);
-
-    mtx_lock(&tss_lock);
-
-    tss_bitmap[key / 32] |= (1 << (key % 32));
-    tss_slots[key] = 0;
+    TlsFree(key);
     tss_dtors[key] = NULL;
-
-    mtx_unlock(&tss_lock);
 }

--- a/platform/xbox/functions/threads/tss_get.c
+++ b/platform/xbox/functions/threads/tss_get.c
@@ -1,10 +1,8 @@
 #include <threads.h>
 #include <assert.h>
-#include <pdclib/_PDCLIB_xbox_tss.h>
+#include <windows.h>
 
 void *tss_get (tss_t key)
 {
-    assert(key < TSS_SLOTS_NUM);
-
-    return tss_slots[key];
+    return TlsGetValue(key);
 }

--- a/platform/xbox/functions/threads/tss_set.c
+++ b/platform/xbox/functions/threads/tss_set.c
@@ -1,11 +1,12 @@
 #include <threads.h>
 #include <assert.h>
-#include <pdclib/_PDCLIB_xbox_tss.h>
+#include <windows.h>
 
 int tss_set (tss_t key, void *val)
 {
-    assert(key < TSS_SLOTS_NUM);
+    if (TlsSetValue(key, val)) {
+        return thrd_success;
+    }
 
-    tss_slots[key] = val;
-    return thrd_success;
+    return thrd_error;
 }

--- a/platform/xbox/include/pdclib/_PDCLIB_config.h
+++ b/platform/xbox/include/pdclib/_PDCLIB_config.h
@@ -535,11 +535,7 @@ typedef unsigned int wint_t;
 #endif
 
 /* threads ------------------------------------------------------------------ */
-typedef struct __PDCLIB_thrd_t
-{
-    void *handle;
-    void *id;
-} _PDCLIB_thrd_t;
+typedef void *_PDCLIB_thrd_t;
 typedef struct __PDCLIB_cnd_t
 {
     void *eventHandles[2]; // [0] single-receiver signal, [1] broadcast signal

--- a/platform/xbox/include/pdclib/_PDCLIB_xbox_tss.h
+++ b/platform/xbox/include/pdclib/_PDCLIB_xbox_tss.h
@@ -1,22 +1,16 @@
 #ifndef _PDCLIB_TSS_H
 #define _PDCLIB_TSS_H _PDCLIB_TSS_H
 
-#include <stdint.h>
 #include <threads.h>
+#include <windows.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define TSS_SLOTS_NUM 64
+void _PDCLIB_xbox_tss_cleanup (void);
 
-extern mtx_t tss_lock;
-extern thread_local void *tss_slots[TSS_SLOTS_NUM];
-extern tss_dtor_t tss_dtors[TSS_SLOTS_NUM];
-extern uint32_t tss_bitmap[TSS_SLOTS_NUM / 32];
-
-void _PDCLIB_xbox_tss_cleanup();
-void _PDCLIB_xbox_tss_init();
+extern tss_dtor_t tss_dtors[FLS_MAXIMUM_AVAILABLE];
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a rewrite of the C11 threads and TSS implementation, basing it on the Win32 implementation. This ensures cross-compatibility, where before it was not possible to use C11 TSS in Win32 threads or vice-versa.
I've recently worked on removing the use of implicit TLS in nxdk itself, which requires these changes to have C11 threads still work.

I've hacked a quick test together to show that TSS still works: https://gist.github.com/thrimbor/014267da6a1c815b2e89bc00c694ba82