### PR TITLE
xbox: Fix tan() implementation

### DIFF
--- a/platform/xbox/functions/math/tan.c
+++ b/platform/xbox/functions/math/tan.c
@@ -3,20 +3,20 @@
 double tan(double x)
 {
     __asm__ ("fptan;"
-             "fstp %%st(0);" : "=t"(x));
+             "fstp %%st(0);" : "+t"(x));
     return x;
 }
 
 float tanf(float x)
 {
     __asm__ ("fptan;"
-             "fstp %%st(0);" : "=t"(x));
+             "fstp %%st(0);" : "+t"(x));
     return x;
 }
 
 long double tanl(long double x)
 {
     __asm__ ("fptan;"
-             "fstp %%st(0);" : "=t"(x));
+             "fstp %%st(0);" : "+t"(x));
     return x;
 }


### PR DESCRIPTION
`tan()` messed up the FPU stack and computed wrong results, because the parameter was not stated as an input in the `asm` statement. I checked the compiler generated assembly for correctness and compared results with glibc, everything seems to work now.

This was a pretty sneaky error, we may have more cases of this elsewhere.

Fixes #36.