### PR TITLE
xbox: Rename XboxCRTEntry to WinMainCRTStartup

### DIFF
--- a/platform/xbox/crt0.c
+++ b/platform/xbox/crt0.c
@@ -46,7 +46,7 @@ static int main_wrapper ()
     return retval;
 }
 
-void XboxCRTEntry ()
+void WinMainCRTStartup ()
 {
     DWORD tlssize;
     // Sum up the required amount of memory, round it up to a multiple of


### PR DESCRIPTION
This renames the entry point from `XboxCRTEntry` to `WinMainCRTStartup`. This doesn't change any behavior, but allows us to drop the `-entry:XboxCRTEntry` linker parameter in nxdk (will have to be done in the same commit as the submodule update, or the build will break).