### PR TITLE
xbox: Work around LLVM LTO symbol issues

### DIFF
--- a/platform/xbox/crt0.c
+++ b/platform/xbox/crt0.c
@@ -4,6 +4,11 @@
 #include <threads.h>
 #include <pdclib/_PDCLIB_xbox_tss.h>
 
+// When using LTO, those symbols may be referenced by code generated at link time.
+// By placing this here, we make sure the linker always includes their bitcode files.
+#pragma comment(linker, "/include:__fltused")
+#pragma comment(linker, "/include:__xlibc_check_stack")
+
 extern const IMAGE_TLS_DIRECTORY_32 _tls_used;
 extern void _PDCLIB_xbox_run_crt_initializers();
 extern int main (int argc, char **argv);


### PR DESCRIPTION
This has the same effect as the `-include:__fltused -include:__xlibc_check_stack` linker parameters, but by including them here, we make sure these parameters get always pulled in (because they're in the same file as the entry point) without having to clutter the cli with so many parameters.