### PR TITLE
xbox: Make _tls_array.s SafeSEH-compatible

### DIFF
--- a/platform/xbox/_tls_array.s
+++ b/platform/xbox/_tls_array.s
@@ -1,3 +1,13 @@
+// This creates a special symbol with the least significant bit set.
+// It signals to the linker that this code is SafeSEH-compatible.
+.text
+.def @feat.00;
+.scl  3; // IMAGE_SYM_CLASS_STATIC
+.type 0; // IMAGE_SYM_TYPE_NULL
+.endef
+.globl @feat.00
+.set @feat.00, 1
+
 .data
 // _tls_array is a constant describing the offset of StackBase inside the NT TEB
 .globl __tls_array


### PR DESCRIPTION
This, along with similar changes in nxdk itself, will allow to build code without having to specify the `-safeseh:no` linker parameter. Currently this causes an error similar to this: `lld: error: /safeseh: .../lib/pdclib/platform/xbox/_tls_array.obj is not compatible with SEH`.

SafeSEH is a security mechanism that involves checking exception handlers against a table of allowed handlers before they're run to combat buffer overflows allowing RCE.
It requires that all object files put a table of all exception handlers in a special section, and include a special marker (the `@feat.00`) with the lsb set to signal their compatibility. For C/C++ files, this is automatically done by clang, but for assembly files, we have to do this manually. Luckily, these files don't contain any exception handlers, so we don't need to actually provide the table, we just need to add the marker.
The code I'm using to add the marker is similar to what clang produces. Also see https://docs.microsoft.com/en-us/windows/win32/debug/pe-format for the meaning of those magic numbers.

Please note that this does not make SafeSEH work, it only fixes linking. Benefiting from SafeSEH will require enhancements to nxdk's exception handling implementation.