### PR TITLE
xbox: Make setjmp/longjmp SafeSEH-compatible

### DIFF
--- a/platform/xbox/functions/setjmp/longjmp.s
+++ b/platform/xbox/functions/setjmp/longjmp.s
@@ -1,3 +1,14 @@
+// This creates a special symbol with the least significant bit set.
+// It signals to the linker that this code is SafeSEH-compatible.
+.text
+.def @feat.00;
+.scl  3; // IMAGE_SYM_CLASS_STATIC
+.type 0; // IMAGE_SYM_TYPE_NULL
+.endef
+.globl @feat.00
+.set @feat.00, 1
+
+
 .text
 
 /*

--- a/platform/xbox/functions/setjmp/setjmp.s
+++ b/platform/xbox/functions/setjmp/setjmp.s
@@ -1,3 +1,14 @@
+// This creates a special symbol with the least significant bit set.
+// It signals to the linker that this code is SafeSEH-compatible.
+.text
+.def @feat.00;
+.scl  3; // IMAGE_SYM_CLASS_STATIC
+.type 0; // IMAGE_SYM_TYPE_NULL
+.endef
+.globl @feat.00
+.set @feat.00, 1
+
+
 .text
 
 /*


### PR DESCRIPTION
This should've been included in #41. It's the same change, so I'm fast-tracking this.