### PR TITLE
xbox: Add includes/alloca.h

### DIFF
--- a/include/alloca.h
+++ b/include/alloca.h
@@ -1,0 +1,1 @@
+#define alloca(size)   __builtin_alloca (size)


### PR DESCRIPTION
This PR adds the file `alloca.h` which provides an implementation of `alloca(size)` according to the manpage.
Implementation might be a bit far fetched as it is just a `#define` to refer to the builtin. 
Having this file simplifies porting of certain programs and libraries. i.e. Micropython. I currently have no way of running xbox executable but at least it compiles fine :p

For my understanding:

1. The program includes `<alloca.h>` expecting to find an implementation of `alloca(size)`
2. The program uses the function accordingly
3. The (preprocessor/)compiler replaces all references to `alloca(size)` with its own builtin
4. The compiler uses its builtin to compile the program. 

This is done because `alloca` operates/allocates on the stack frame - which is handled by the compiler, not the OS(as given when using `malloc`). Additionally, it is therefore compiler(and machine) depended wich builtin/implementation is to be used.
Right? 😅

I'm not sure if the PR belongs here or if it is okay at all. So don't feel bad when giving hard backlash in the review. 
Edit:
Maybe I should have done something similar to [this](https://github.com/XboxDev/nxdk/blob/master/lib/xboxrt/libc_extensions/malloc.h) and place it in nxdk/libs/xboxrt/alloca.h

Additionally, this is according to the [manpage of alloca](https://www.man7.org/linux/man-pages/man3/alloca.3.html) commonly found on modern *nix systems.