### PR TITLE
Fix strict prototypes warning

### DIFF
--- a/platform/xbox/crt0.c
+++ b/platform/xbox/crt0.c
@@ -11,14 +11,14 @@
 
 extern const IMAGE_TLS_DIRECTORY_32 _tls_used;
 extern void __cdecl __security_init_cookie (void);
-extern void _PDCLIB_xbox_run_crt_initializers();
+extern void _PDCLIB_xbox_run_crt_initializers (void);
 extern int main (int argc, char **argv);
 extern mtx_t _PDCLIB_filelist_mtx;
 extern struct _PDCLIB_file_t * stdin;
 extern struct _PDCLIB_file_t * stdout;
 extern struct _PDCLIB_file_t * stderr;
 
-void _PDCLIB_xbox_libc_init ()
+void _PDCLIB_xbox_libc_init (void)
 {
     mtx_init(&_PDCLIB_filelist_mtx, mtx_plain);
     mtx_init(&stdin->mtx, mtx_recursive);
@@ -26,7 +26,7 @@ void _PDCLIB_xbox_libc_init ()
     mtx_init(&stderr->mtx, mtx_recursive);
 }
 
-void _PDCLIB_xbox_libc_deinit ()
+void _PDCLIB_xbox_libc_deinit (void)
 {
     mtx_destroy(&_PDCLIB_filelist_mtx);
     mtx_destroy(&stdin->mtx);
@@ -34,7 +34,7 @@ void _PDCLIB_xbox_libc_deinit ()
     mtx_destroy(&stderr->mtx);
 }
 
-static int main_wrapper ()
+static int main_wrapper (__attribute__((unused)) void *unused_param)
 {
     int retval;
     char *_argv = 0;
@@ -47,7 +47,7 @@ static int main_wrapper ()
     return retval;
 }
 
-void __attribute__((no_stack_protector)) WinMainCRTStartup ()
+void __attribute__((no_stack_protector)) WinMainCRTStartup (void)
 {
     // The security cookie needs to be initialized as early as possible, and from a non-protected function
     __security_init_cookie();

--- a/platform/xbox/crt_initializers.c
+++ b/platform/xbox/crt_initializers.c
@@ -10,7 +10,7 @@ __attribute__((section(".CRT$XIZ"))) _PIFV __xi_z[] = {0};
 __attribute__((section(".CRT$XCA"))) _PVFV __xc_a[] = {0};
 __attribute__((section(".CRT$XCZ"))) _PVFV __xc_z[] = {0};
 
-void _PDCLIB_xbox_run_crt_initializers()
+void _PDCLIB_xbox_run_crt_initializers (void)
 {
     int ret = 0;
 

--- a/platform/xbox/functions/_PDCLIB/_PDCLIB_stdinit.c
+++ b/platform/xbox/functions/_PDCLIB/_PDCLIB_stdinit.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <locale.h>
 #include <limits.h>
+#include <winbase.h>
 
 #ifndef REGTEST
 
@@ -27,17 +28,17 @@ static unsigned char _PDCLIB_sin_ungetbuf[_PDCLIB_UNGETCBUFSIZE];
 static unsigned char _PDCLIB_sout_ungetbuf[_PDCLIB_UNGETCBUFSIZE];
 static unsigned char _PDCLIB_serr_ungetbuf[_PDCLIB_UNGETCBUFSIZE];
 
-static struct _PDCLIB_file_t _PDCLIB_serr = { 2, _PDCLIB_serr_buffer, BUFSIZ, 0, 0, { 0, 0 }, 0, _PDCLIB_serr_ungetbuf, _IONBF | _PDCLIB_FWRITE | _PDCLIB_STATIC,
+static struct _PDCLIB_file_t _PDCLIB_serr = { INVALID_HANDLE_VALUE, _PDCLIB_serr_buffer, BUFSIZ, 0, 0, { 0, 0 }, 0, _PDCLIB_serr_ungetbuf, _IONBF | _PDCLIB_FWRITE | _PDCLIB_STATIC,
 #ifndef __STDC_NO_THREADS__
     0,
 #endif
    NULL, NULL };
-static struct _PDCLIB_file_t _PDCLIB_sout = { 1, _PDCLIB_sout_buffer, BUFSIZ, 0, 0, { 0, 0 }, 0, _PDCLIB_sout_ungetbuf, _IOLBF | _PDCLIB_FWRITE | _PDCLIB_STATIC,
+static struct _PDCLIB_file_t _PDCLIB_sout = { INVALID_HANDLE_VALUE, _PDCLIB_sout_buffer, BUFSIZ, 0, 0, { 0, 0 }, 0, _PDCLIB_sout_ungetbuf, _IOLBF | _PDCLIB_FWRITE | _PDCLIB_STATIC,
 #ifndef __STDC_NO_THREADS__
     0,
 #endif
     NULL, &_PDCLIB_serr };
-static struct _PDCLIB_file_t _PDCLIB_sin  = { 0, _PDCLIB_sin_buffer, BUFSIZ, 0, 0, { 0, 0 }, 0, _PDCLIB_sin_ungetbuf, _IOLBF | _PDCLIB_FREAD | _PDCLIB_STATIC,
+static struct _PDCLIB_file_t _PDCLIB_sin  = { INVALID_HANDLE_VALUE, _PDCLIB_sin_buffer, BUFSIZ, 0, 0, { 0, 0 }, 0, _PDCLIB_sin_ungetbuf, _IOLBF | _PDCLIB_FREAD | _PDCLIB_STATIC,
 #ifndef __STDC_NO_THREADS__
     0,
 #endif


### PR DESCRIPTION
Fixes `-Wstrict-prototypes` warnings, just like https://github.com/XboxDev/nxdk/pull/475. Related to https://github.com/XboxDev/nxdk/issues/468.