### PR TITLE
xbox: Fix assert() compatibility with comma operator

### DIFF
--- a/platform/xbox/include/assert.h
+++ b/platform/xbox/include/assert.h
@@ -22,14 +22,11 @@ void _xbox_assert(char const * const expression, char const * const file_name, c
     #define assert(ignore) ((void)0)
 #else
     #define assert(expression) \
-        do { \
-            if(!(expression)) { \
-                _xbox_assert(_PDCLIB_symbol2string(expression), \
-                             __FILE__, \
-                             __func__, \
-                             __LINE__); \
-            } \
-        } while(0)
+        ((void) ((expression) ? 0 :  \
+            (_xbox_assert(_PDCLIB_symbol2string(expression), \
+                          __FILE__, \
+                          __func__, \
+                          __LINE__), 0)))
 #endif
 
 #define static_assert _Static_assert


### PR DESCRIPTION
This fixes an issue I encountered when testing a project of mine, which involved producing a debug build of zstd. This is the line that triggered the issue:

https://github.com/facebook/zstd/blob/a488ba114ec17ea1054b9057c26a046fc122b3b6/lib/compress/zstdmt_compress.c#L1254

The zstd code is using the comma operator to combine the assert statement with the assignment of a value without starting a block. Unfortunately there are limits of what constructs you are allowed to put in such an expression, and a do-while loop apparently is not one of them.

I fixed it by rewriting our assert macro to using the exact same feature to add the internal function call, thereby avoiding the loop. This seems to fix the issue, while not introducing issues with our other code.

Here's a boiled-down demonstration of the issue:
```C
#include <assert.h>
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
    int const testvar = (assert(0), 10);
    debugPrint("Hello nxdk!\n");

    while(1) {
        Sleep(2000);
    }

    return 0;
}
```
