### PR TITLE
xbox: Run constructors in main thread, provide mechanism for old way

### DIFF
--- a/platform/xbox/crt0.c
+++ b/platform/xbox/crt0.c
@@ -36,6 +36,7 @@ void _PDCLIB_xbox_libc_deinit (void)
 
 static int main_wrapper (__attribute__((unused)) void *unused_param)
 {
+    _PDCLIB_xbox_run_crt_initializers();
     int retval;
     char *_argv = 0;
     retval = main(0, &_argv);
@@ -61,7 +62,6 @@ void __attribute__((no_stack_protector)) WinMainCRTStartup (void)
     *((DWORD *)_tls_used.AddressOfIndex) = (int)tlssize / -4;
 
     _PDCLIB_xbox_libc_init();
-    _PDCLIB_xbox_run_crt_initializers();
 
     thrd_t main_thread;
     thrd_create(&main_thread, main_wrapper, NULL);

--- a/platform/xbox/crt0.c
+++ b/platform/xbox/crt0.c
@@ -11,6 +11,7 @@
 
 extern const IMAGE_TLS_DIRECTORY_32 _tls_used;
 extern void __cdecl __security_init_cookie (void);
+extern void _PDCLIB_xbox_run_pre_initializers (void);
 extern void _PDCLIB_xbox_run_crt_initializers (void);
 extern int main (int argc, char **argv);
 extern mtx_t _PDCLIB_filelist_mtx;
@@ -62,6 +63,7 @@ void __attribute__((no_stack_protector)) WinMainCRTStartup (void)
     *((DWORD *)_tls_used.AddressOfIndex) = (int)tlssize / -4;
 
     _PDCLIB_xbox_libc_init();
+    _PDCLIB_xbox_run_pre_initializers();
 
     thrd_t main_thread;
     thrd_create(&main_thread, main_wrapper, NULL);

--- a/platform/xbox/crt_initializers.c
+++ b/platform/xbox/crt_initializers.c
@@ -9,6 +9,19 @@ __attribute__((section(".CRT$XIA"))) _PIFV __xi_a[] = {0};
 __attribute__((section(".CRT$XIZ"))) _PIFV __xi_z[] = {0};
 __attribute__((section(".CRT$XCA"))) _PVFV __xc_a[] = {0};
 __attribute__((section(".CRT$XCZ"))) _PVFV __xc_z[] = {0};
+__attribute__((section(".CRT$XXA"))) _PVFV __xx_a[] = {0};
+__attribute__((section(".CRT$XXZ"))) _PVFV __xx_z[] = {0};
+
+void _PDCLIB_xbox_run_pre_initializers (void)
+{
+    for (_PVFV *pf = __xx_a; pf < __xx_z; pf++)
+    {
+        if (*pf)
+        {
+            (**pf)();
+        }
+    }
+}
 
 void _PDCLIB_xbox_run_crt_initializers (void)
 {


### PR DESCRIPTION
This changes our startup code to run constructors in the main thread instead of the startup thread. This is necessary because constructors might require functional thread-local storage, which is not available from the startup thread, causing issues such as https://github.com/XboxDev/nxdk/issues/496

This change alone will lead to crashes if not combined with the change in https://github.com/XboxDev/nxdk/pull/497.
