### PR TITLE
Fixed an error

### DIFF
--- a/platform/xbox/functions/math/nearbyint.c
+++ b/platform/xbox/functions/math/nearbyint.c
@@ -1,7 +1,7 @@
 #include <math.h>
 #include <fenv.h>
 
-#pragma STDC FENV_ACCESS ON
+//#pragma STDC FENV_ACCESS ON // Causes "'#pragma STDC FENV_ACCESS ON' is illegal when precise is disabled"
 
 double nearbyint(double x)
 {


### PR DESCRIPTION
`#pragma STDC FENV_ACCESS ON` on line 4 of `platform/xbox/functions/math/nearbyint.c` causes
```
/home/pqcraft/Documents/git/nxdk//lib/pdclib/platform/xbox/functions/math/nearbyint.c:4:14: error: '#pragma STDC FENV_ACCESS ON' is illegal when precise is disabled
#pragma STDC FENV_ACCESS ON
             ^
1 warning and 1 error generated.
```