### PR TITLE
xbox: Fix fast64 type

### DIFF
--- a/platform/xbox/include/pdclib/_PDCLIB_config.h
+++ b/platform/xbox/include/pdclib/_PDCLIB_config.h
@@ -126,8 +126,8 @@ struct _PDCLIB_lldiv_t
 #define _PDCLIB_fast32 int
 #define _PDCLIB_FAST32_CONV
 
-#define _PDCLIB_FAST64 LONG
-#define _PDCLIB_fast64 long
+#define _PDCLIB_FAST64 LLONG
+#define _PDCLIB_fast64 long long
 #define _PDCLIB_FAST64_CONV l
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
fast64 should be 8 bytes (long long)
Encountered when I was using https://github.com/charlesnicholson/nanoprintf and it wasnt working correctly.