### PR TITLE
xbox: Use RtlSnprintf in assert under `DEBUG_CONSOLE`

### DIFF
--- a/platform/xbox/functions/assert/assert.c
+++ b/platform/xbox/functions/assert/assert.c
@@ -9,7 +9,7 @@ void _xbox_assert(char const * const expression, char const * const file_name, c
 {
 #ifdef DEBUG_CONSOLE
     char buffer[512];
-    snprintf(buffer, 512, "In function '%s': ", function_name);
+    RtlSnprintf(buffer, 512, "In function '%s': ", function_name);
     RtlAssert((PVOID)expression, (PVOID)file_name, line, buffer);
 #else
     debugPrint("\nAssertion failed: '%s' in function '%s', file '%s', line %lu\n", expression, function_name, file_name, line);


### PR DESCRIPTION
```
[ CC       ] /home/sl/testing/nxdk/lib/pdclib/platform/xbox/functions/assert/assert.obj
In file included from /home/sl/testing/nxdk/lib/pdclib/platform/xbox/functions/assert/assert.c:1:
/home/sl/testing/nxdk/lib/pdclib/platform/xbox/include/assert.h:33:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]
   33 | #define static_assert _Static_assert
      |         ^
/home/sl/testing/nxdk/lib/pdclib/platform/xbox/functions/assert/assert.c:12:5: error: call to undeclared function 'snprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   12 |     snprintf(buffer, 512, "In function '%s': ", function_name);
      |     ^
/home/sl/testing/nxdk/lib/pdclib/platform/xbox/functions/assert/assert.c:12:5: note: did you mean '_snwprintf'?
/home/sl/testing/nxdk/lib/xboxrt/libc_extensions/wchar_ext_.h:10:5: note: '_snwprintf' declared here
   10 | int _snwprintf(wchar_t *buffer, size_t count, const wchar_t *format, ...);
      |     ^
1 warning and 1 error generated.
```

When setting `-DNDEBUG -DDEBUG_CONSOLE`, this error is produced.
